### PR TITLE
fixed corpus/uploader

### DIFF
--- a/corpus/uploader.py
+++ b/corpus/uploader.py
@@ -16,13 +16,14 @@ from qdrant_client.models import (
 )
 
 from corpus.schemas import Passage
+from config.settings import settings
 
 COLLECTION_NAME = "legal_corpus"
 VECTOR_SIZE = 768  # InLegalBERT hidden size
 
 
-def get_client(url: str = "http://localhost:6333") -> QdrantClient:
-    return QdrantClient(url=url)
+def get_client(url: str | None = None) -> QdrantClient:
+    return QdrantClient(url=url or settings.qdrant_url)
 
 
 def ensure_collection(client: QdrantClient) -> None:


### PR DESCRIPTION
# Summary
Fixes #30
`corpus/uploader.py`'s `get_client()` hardcoded `http://localhost:6333` as its default URL, bypassing `settings.qdrant_url` entirely. `corpus/search.py`'s `lookup_section()` falls back to this same `get_client()` when no client is passed, so both were silently ignoring the `QDRANT_URL` env var while `api/routes/health.py` and `rules/citation_checker.py` (which build their own `QdrantClient(url=settings.qdrant_url)` directly) correctly respected it.

---
# Changes
- `get_client()` in `corpus/uploader.py` now defaults its `url` param to `settings.qdrant_url` instead of a hardcoded string; explicit `url=` override still works for tests/scripts that need it
- `corpus/search.py` needed no changes — its fallback (`client or get_client()`) now resolves correctly for free

---
# Testing
- [ ] Unit tests pass

No automated tests exist for this area yet (#50). Verified manually:
- Confirmed the bug was live: `corpus/ingest.py` calls `get_client()` with no args, so it was the actual affected caller
- With no `QDRANT_URL` set, `get_client()` still resolves to `http://localhost:6333` (unchanged default behavior)
- With `QDRANT_URL=http://qdrant-prod:6333` set in env, `settings.qdrant_url` and therefore `get_client()`'s default now correctly resolve to the overridden value
- Both edited files still parse cleanly

---
# Documentation
- [ ] Documentation updated if required

None needed — this doesn't change any documented behavior or interface, just fixes a default to match what was already documented/assumed.

---
# Checklist
- [x] No unnecessary files committed
- [x] Code follows project conventions
- [x] Ready for review