### PR TITLE
fixes loading model  on each doc inside predict and preprocess

### DIFF
--- a/model/predict.py
+++ b/model/predict.py
@@ -35,7 +35,21 @@ def _checkpoint_exists() -> bool:
     return os.path.isfile(os.path.join(CHECKPOINT_DIR, "config.json"))
 
 
+# module-level cache so the (fine-tuned or base) InLegalBERT weights and
+# tokenizer only get loaded from disk once per process, not once per
+# document. a Celery worker handles many documents over its lifetime —
+# without this, every single upload paid the full model-load cost again.
+_CACHED_MODEL = None
+_CACHED_TOKENIZER = None
+_CACHED_DEVICE = None
+
+
 def _load_model_and_tokenizer():
+    global _CACHED_MODEL, _CACHED_TOKENIZER, _CACHED_DEVICE
+
+    if _CACHED_MODEL is not None:
+        return _CACHED_MODEL, _CACHED_TOKENIZER, _CACHED_DEVICE
+
     device = _get_device()
 
     if _checkpoint_exists():
@@ -60,6 +74,7 @@ def _load_model_and_tokenizer():
     model.to(device)
     model.eval()  # never skip this — eval mode disables dropout and halves memory vs train mode
 
+    _CACHED_MODEL, _CACHED_TOKENIZER, _CACHED_DEVICE = model, tokenizer, device
     return model, tokenizer, device
 
 

--- a/model/preprocess.py
+++ b/model/preprocess.py
@@ -20,6 +20,19 @@ from config.settings import settings
 from config.constants import MAX_TOKENS, CHUNK_STRIDE
 CHECKPOINT = settings.bert_checkpoint 
 
+# separate cache from model/predict.py's — this tokenizer is only used
+# here to build chunks, before we even know if we'll run the ML model.
+# keeping the two caches independent avoids a circular import (predict.py
+# already imports Chunk from this file).
+_CACHED_TOKENIZER = None
+
+
+def _get_tokenizer():
+    global _CACHED_TOKENIZER
+    if _CACHED_TOKENIZER is None:
+        _CACHED_TOKENIZER = AutoTokenizer.from_pretrained(CHECKPOINT)
+    return _CACHED_TOKENIZER
+
 
 @dataclass
 class Chunk:
@@ -37,7 +50,7 @@ def build_chunks(spans: list[LineSpan]) -> list[Chunk]:
     each chunk fits within MAX_TOKENS including [CLS] and [SEP].
     chunks overlap by STRIDE tokens so nothing at a boundary is missed.
     """
-    tokenizer = AutoTokenizer.from_pretrained(CHECKPOINT)
+    tokenizer = _get_tokenizer()
 
     # step 1: tokenize each span individually and record which span
     # each token came from. we don't chunk yet, just flatten everything.


### PR DESCRIPTION
# Summary
Fixes #35
`model/predict.py` and `model/preprocess.py` each reloaded InLegalBERT/tokenizer from scratch on every document — no caching, no warm-up. In a long-running Celery worker handling many documents, this meant paying the full model-load cost (disk read + weight init + `.to(device)`) on every single upload instead of once per process.

---
# Changes
- `model/predict.py`: `_load_model_and_tokenizer()` now checks a module-level cache (`_CACHED_MODEL` / `_CACHED_TOKENIZER` / `_CACHED_DEVICE`) first and only loads from disk if empty
- `model/preprocess.py`: `build_chunks()` now calls a new `_get_tokenizer()` helper backed by its own separate module-level cache, instead of calling `AutoTokenizer.from_pretrained()` directly every time

Kept the two caches independent (rather than having `preprocess.py` reuse `predict.py`'s tokenizer) to avoid introducing a circular import — `predict.py` already imports `Chunk` from `preprocess.py`. This costs one extra tokenizer instance in memory but keeps the fix minimal and the two files decoupled, consistent with how the act parsers are kept independent rather than sharing a base class.

---
# Testing
- [ ] Unit tests pass

No automated tests exist for this area yet (#50), and running with real InLegalBERT weights isn't practical here. Verified the caching logic itself with mocked `transformers`/`torch` stand-ins simulating 3 sequential "documents":
- BERT model loaded **1** time across 3 simulated documents (previously would've been 3)
- Each tokenizer cache (`predict.py`'s and `preprocess.py`'s) loaded **1** time each across 3 simulated documents (previously would've been 3 each)
- Both files still parse and import cleanly

---
# Documentation
- [ ] Documentation updated if required

None needed.

---
# Checklist
- [x] No unnecessary files committed
- [x] Code follows project conventions
- [x] Ready for review