### PR TITLE
fix(frontend): add total_pages to report, bound page navigation (#51)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -87,6 +87,13 @@ export default function App() {
     }
   }, [jobId])
 
+  // report.total_pages comes straight from renderer/report.py and is known
+  // the instant the report loads - pageInfo.numPages only exists after
+  // pdf.js finishes parsing the file client-side, a moment later. prefer
+  // the backend value; fall back to pdf.js's count if a report predates
+  // this field (e.g. one saved before total_pages was added).
+  const totalPages = report?.total_pages || pageInfo?.numPages || null
+
   const pageErrors = useMemo(
     () => report?.errors.filter((e) => e.page_no === currentPage) ?? [],
     [report, currentPage],
@@ -133,8 +140,8 @@ export default function App() {
           <span className="viewer-page-label">Page {currentPage}</span>
           <button
             type="button"
-            disabled={pageInfo?.numPages != null && currentPage >= pageInfo.numPages}
-            onClick={() => setCurrentPage((p) => p + 1)}
+            disabled={totalPages != null && currentPage >= totalPages}
+            onClick={() => setCurrentPage((p) => Math.min(totalPages ?? p + 1, p + 1))}
           >
             Next →
           </button>

--- a/frontend/src/mockData.js
+++ b/frontend/src/mockData.js
@@ -1,7 +1,7 @@
 /*
   mock data shaped exactly like renderer/report.py's build_report() output -
-  same keys (source_filename, total_errors, errors_by_type, errors[]), same
-  per-error fields (bbox, highlight_color, confidence, etc).
+  same keys (source_filename, total_pages, total_errors, errors_by_type,
+  errors[]), same per-error fields (bbox, highlight_color, confidence, etc).
 
   the point: api.js's real implementation (once api/routes/jobs.py exists)
   just needs to return this same shape, and nothing else in the app changes.
@@ -68,6 +68,7 @@ export function buildMockReport(sourceFilename) {
 
   return {
     source_filename: sourceFilename,
+    total_pages: 2,
     total_errors: errors.length,
     errors_by_type,
     errors,

--- a/renderer/annotate_pdf.py
+++ b/renderer/annotate_pdf.py
@@ -29,12 +29,21 @@ from config.constants import FILL_ALPHA, STROKE_ALPHA, STROKE_WIDTH
 
 
 
-def annotate(pdf_path: Path, errors: list[ErrorSpan], output_path: Path) -> None:
-    """reads pdf_path, draws every error's highlight box, writes the result to output_path."""
+def annotate(pdf_path: Path, errors: list[ErrorSpan], output_path: Path) -> int:
+    """
+    reads pdf_path, draws every error's highlight box, writes the result to
+    output_path. returns the total page count - this is already sitting
+    right here in reader.pages, and it's the one place in the whole
+    pipeline that reliably knows it (span-derived counts can silently
+    undercount if noise-filtering strips every span on a page), so callers
+    that need total_pages (see services/analysis.py -> build_report) get
+    it from here instead of opening the PDF a second time.
+    """
     reader = PdfReader(str(pdf_path))
     writer = PdfWriter()
 
     errors_by_page = _group_by_page(errors)
+    total_pages = len(reader.pages)
 
     for page_no, page in enumerate(reader.pages, start=1):
         page_errors = errors_by_page.get(page_no, [])
@@ -48,6 +57,8 @@ def annotate(pdf_path: Path, errors: list[ErrorSpan], output_path: Path) -> None
     output_path.parent.mkdir(parents=True, exist_ok=True)
     with open(output_path, "wb") as f:
         writer.write(f)
+
+    return total_pages
 
 
 def _group_by_page(errors: list[ErrorSpan]) -> dict[int, list[ErrorSpan]]:

--- a/renderer/report.py
+++ b/renderer/report.py
@@ -9,13 +9,18 @@ from dataclasses import asdict
 from model.schemas import ErrorSpan
 
 
-def build_report(errors: list[ErrorSpan], source_filename: str = "") -> dict:
+def build_report(
+    errors: list[ErrorSpan],
+    source_filename: str = "",
+    total_pages: int = 0,
+) -> dict:
     errors_by_type: dict[str, int] = {}
     for error in errors:
         errors_by_type[error.error_type] = errors_by_type.get(error.error_type, 0) + 1
 
     return {
         "source_filename": source_filename,
+        "total_pages": total_pages,
         "total_errors": len(errors),
         "errors_by_type": errors_by_type,
         "errors": [_error_to_dict(e) for e in errors],

--- a/scripts/smoke_test.py
+++ b/scripts/smoke_test.py
@@ -42,10 +42,10 @@ def main():
     args.out.mkdir(parents=True, exist_ok=True)
 
     annotated_path = args.out / f"{args.pdf.stem}_annotated.pdf"
-    annotate(args.pdf, errors, annotated_path)
+    total_pages = annotate(args.pdf, errors, annotated_path)
     print(f"annotated PDF: {annotated_path}")
 
-    report = build_report(errors, source_filename=args.pdf.name)
+    report = build_report(errors, source_filename=args.pdf.name, total_pages=total_pages)
     report_path = args.out / f"{args.pdf.stem}_report.html"
     render_html(report, report_path)
     print(f"HTML report: {report_path}")

--- a/services/analysis.py
+++ b/services/analysis.py
@@ -36,9 +36,9 @@ def run_analysis(job_id: str) -> dict:
     spans = extract(pdf_path)
     errors = analyze(spans)
 
-    annotate(pdf_path, errors, annotated_pdf_path(job_id))
+    total_pages = annotate(pdf_path, errors, annotated_pdf_path(job_id))
 
-    report = build_report(errors, source_filename=source_filename)
+    report = build_report(errors, source_filename=source_filename, total_pages=total_pages)
     report_json_path(job_id).parent.mkdir(parents=True, exist_ok=True)
     report_json_path(job_id).write_text(json.dumps(report, indent=2))
 


### PR DESCRIPTION
# Summary

Fixes #51

The Next button already had a client-side guard using pdf.js's
`numPages`, but that value isn't known until pdf.js finishes parsing
the file — a moment after the report loads. This adds `total_pages`
to the backend report shape (`renderer/report.py`) so the bound is
available immediately, using pdf.js's count only as a fallback.

---

# Changes

- `renderer/annotate_pdf.py` — `annotate()` returns `total_pages`
  (`len(reader.pages)`) instead of `None`, since it already opens and
  iterates the PDF's pages
- `renderer/report.py` — `build_report()` takes a `total_pages` param
  and includes it in the output dict
- `services/analysis.py` — captures `annotate()`'s return value and
  passes it into `build_report()`
- `scripts/smoke_test.py` — updated the same call site for consistency
- `frontend/src/App.jsx` — Next button bounds on `report.total_pages`,
  falling back to `pageInfo.numPages`; click handler clamps instead of
  incrementing unconditionally
- `frontend/src/mockData.js` — updated to match the new report shape
- `frontend/src/api.js` — no change needed; it already spreads
  `...data.report` generically, so `total_pages` flows through as-is

---

# Testing

- [x] Unit tests pass
- [x] `python3 -m py_compile` on all touched Python files
- [x] Verified `build_report(...)` carries `total_pages` correctly
- [x] Generated a 3-page PDF with pypdf and confirmed `annotate()`
      returns `3`
- [x] `npm install && npm run build` succeeds on the frontend with the
      JSX changes

---

# Documentation

- [ ] Documentation updated if required

---

# Checklist

- [x] No unnecessary files committed
- [x] Code follows project conventions
- [x] Ready for review