### PR TITLE
fixes #38

### DIFF
--- a/model/postprocess.py
+++ b/model/postprocess.py
@@ -160,4 +160,5 @@ def _build_span(
         page_no=source_spans[0].page_no,
         x0=x0, y0=y0, x1=x1, y1=y1,
         confidence=confidence,
+        source= "model",
     )

--- a/model/schemas.py
+++ b/model/schemas.py
@@ -35,6 +35,7 @@ class ErrorSpan:
     y1: float
     suggestion: str = ""      # suggested correction, empty until we have a correction model
     confidence: float = 0.0   # model confidence score for this span
+    source: str = ""           # source of the error span
 
     @property
     def bbox(self):

--- a/renderer/html_report.py
+++ b/renderer/html_report.py
@@ -71,12 +71,13 @@ def _error_row(error: dict) -> str:
         f'<td>{_escape(error["text"])}</td>'
         f'<td>{_escape(error.get("suggestion") or "—")}</td>'
         f'<td>{conf_str}</td>'
+        f'<td>{_escape(error.get("source") or "—")}</td>'
         "</tr>"
     )
 
 
 def _empty_row() -> str:
-    return '<tr><td colspan="5">No errors found.</td></tr>'
+    return '<tr><td colspan="6">No errors found.</td></tr>'
 
 
 def _escape(text: str) -> str:

--- a/rules/citation_checker.py
+++ b/rules/citation_checker.py
@@ -85,6 +85,7 @@ def _check_span(span: LineSpan, client: QdrantClient) -> list[ErrorSpan]:
                     x0=span.x0, y0=span.y0, x1=span.x1, y1=span.y1,
                     suggestion=f"verify Section {section_no} {resolved_act} exists and is active",
                     confidence=0.95,  # regex match is deterministic, high confidence
+                    source="citation_rule",
                 ))
 
     return errors

--- a/rules/cross_reference_checker.py
+++ b/rules/cross_reference_checker.py
@@ -108,6 +108,7 @@ def check_cross_references(spans: list[LineSpan]) -> list[ErrorSpan]:
                 y1=ref["span"].y1,
                 suggestion=f'"{ref["target"]}" is referenced but never defined in this document',
                 confidence=0.90,
+                source="cross_reference_rule",
             ))
 
     return errors

--- a/rules/entity_checker.py
+++ b/rules/entity_checker.py
@@ -200,6 +200,7 @@ def _flag_deviations(clusters: list[list[dict]], spans: list[LineSpan]) -> list[
                 confidence=round(
                     fuzz.ratio(mention["text"].lower(), canonical.lower()) / 100, 2
                 ),
+                source="entity_rule",
             ))
 
     return errors


### PR DESCRIPTION
## Summary

Fixes #38 — adds a `source` field to `ErrorSpan` so every error carries provenance about which subsystem produced it (ML model, citation rule, entity rule, or cross-reference rule), and threads that value through to the JSON and HTML reports.

## Changes

- **`model/schemas.py`** — added `source: str = ""` field to `ErrorSpan`
- **`model/postprocess.py`** — tag ML-produced spans with `source="model"`
- **`rules/citation_checker.py`** — tag citation errors with `source="citation_rule"`
- **`rules/entity_checker.py`** — tag entity errors with `source="entity_rule"`
- **`rules/cross_reference_checker.py`** — tag cross-reference errors with `source="cross_reference_rule"` (not explicitly named in #38, but required to meet the "every ErrorSpan" done-when criterion since this checker is live in `registry.py`)
- **`renderer/report.py`** — no change needed; `asdict()` picks up the new field automatically
- **`renderer/html_report.py`** — added a "Source" column to the report table, updated `_error_row()`, bumped `_empty_row()` colspan from 5 → 6

## Testing

- [ ] Unit tests pass

> `test_rules.py` / `test_model.py` are currently stub `pass` files per #50 — no real coverage exists to run against this change yet. Manually verified `source` appears correctly in a sample JSON report and renders in the HTML table.

## Documentation

- [ ] Documentation updated if required

N/A — internal field addition, no user-facing docs reference `ErrorSpan`'s schema.

## Checklist

- [x] No unnecessary files committed
- [x] Code follows project conventions
- [x] Ready for review