### PR TITLE
fix page_no off-by-one + add fit-to-width/zoom to PDF viewer

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -118,6 +118,11 @@
   margin: 0.15rem 0 0;
 }
 
+.viewer-header-controls {
+  display: flex;
+  align-items: center;
+}
+
 .viewer-page-nav {
   display: flex;
   align-items: center;
@@ -144,6 +149,37 @@
   color: var(--ink-muted);
   min-width: 4.5rem;
   text-align: center;
+}
+
+.viewer-zoom-nav {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  margin-left: 1rem;
+  padding-left: 1rem;
+  border-left: 1px solid var(--hairline);
+}
+
+.viewer-zoom-nav button {
+  border: 1px solid var(--hairline);
+  background: var(--surface);
+  border-radius: 6px;
+  padding: 0.35rem 0.6rem;
+  cursor: pointer;
+  color: var(--ink);
+  line-height: 1;
+}
+
+.viewer-zoom-nav button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.viewer-zoom-reset {
+  min-width: 3.6rem;
+  color: var(--ink-muted);
 }
 
 .viewer-body {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import './App.css'
 import UploadPage from './UploadPage'
 import PdfCanvas from './PdfCanvas'
@@ -8,6 +8,9 @@ import ErrorList from './ErrorList'
 import { uploadPdf, pollJobStatus, fetchResult } from './api'
 
 const POLL_INTERVAL_MS = 300
+const ZOOM_STEP = 0.15
+const ZOOM_MIN = 0.4
+const ZOOM_MAX = 3
 
 export default function App() {
   const [file, setFile] = useState(null)
@@ -18,6 +21,42 @@ export default function App() {
   const [currentPage, setCurrentPage] = useState(1)
   const [activeErrorIndex, setActiveErrorIndex] = useState(null)
   const [pageInfo, setPageInfo] = useState(null) // { widthPts, heightPts, displayScale, numPages }
+  const [zoom, setZoom] = useState(1) // user multiplier on top of fit-to-width; 1 = fit exactly
+
+  // PdfCanvas sizes itself to fill this rather than a fixed 1-point-per-
+  // CSS-pixel size (which renders as a small rectangle in a sea of empty
+  // space on any normal monitor - see PdfCanvas.jsx's docstring). tracked
+  // via ResizeObserver rather than window resize alone, since the sidebar
+  // or margin rail resizing (not just the window) also changes how much
+  // width is actually available.
+  const canvasAreaRef = useRef(null)
+  const [containerWidth, setContainerWidth] = useState(null)
+
+  useEffect(() => {
+    const el = canvasAreaRef.current
+    if (!el) return
+
+    // leaves room for the canvas area's own horizontal padding (2rem each
+    // side, see .viewer-canvas-area) and the margin rail beside it, so
+    // "fit width" doesn't fit right up against - or past - the scrollbar.
+    const HORIZONTAL_ALLOWANCE = 96
+
+    const observer = new ResizeObserver((entries) => {
+      const width = entries[0]?.contentRect.width
+      if (width) setContainerWidth(Math.max(200, width - HORIZONTAL_ALLOWANCE))
+    })
+    observer.observe(el)
+    return () => observer.disconnect()
+    // deps: [report], not [] - canvasAreaRef.current is null until the
+    // viewer JSX (below, behind `if (!report) return <UploadPage/>`)
+    // actually mounts, which only happens once report is first set. an
+    // empty dep array would run this exactly once, before that div
+    // exists, capture a null ref, and never observe anything.
+  }, [report])
+
+  const zoomIn = useCallback(() => setZoom((z) => Math.min(ZOOM_MAX, +(z + ZOOM_STEP).toFixed(2))), [])
+  const zoomOut = useCallback(() => setZoom((z) => Math.max(ZOOM_MIN, +(z - ZOOM_STEP).toFixed(2))), [])
+  const resetZoom = useCallback(() => setZoom(1), [])
 
   const handleFileSelected = useCallback(async (selectedFile) => {
     setFile(selectedFile)
@@ -94,15 +133,22 @@ export default function App() {
   // this field (e.g. one saved before total_pages was added).
   const totalPages = report?.total_pages || pageInfo?.numPages || null
 
+  // report.errors[].page_no is 0-indexed (see ocr/native_extractor.py and
+  // ocr/surya_extractor.py, both built via plain enumerate(pages)/pymupdf's
+  // doc[i]) - currentPage is 1-indexed to match pdf.js's getPage() and the
+  // "Page 1" label shown in the header, so every read/write of page_no
+  // needs a +/-1 conversion at this boundary. getting this wrong doesn't
+  // error out, it just silently shows zero highlights on the very page
+  // an error is actually on.
   const pageErrors = useMemo(
-    () => report?.errors.filter((e) => e.page_no === currentPage) ?? [],
+    () => report?.errors.filter((e) => e.page_no === currentPage - 1) ?? [],
     [report, currentPage],
   )
 
   function selectError(globalIndex) {
     const error = report.errors[globalIndex]
     setActiveErrorIndex(globalIndex)
-    if (error.page_no !== currentPage) setCurrentPage(error.page_no)
+    if (error.page_no !== currentPage - 1) setCurrentPage(error.page_no + 1)
   }
 
   function selectPageError(pageLocalIndex) {
@@ -114,7 +160,7 @@ export default function App() {
   const activeIndexOnPage = useMemo(() => {
     if (activeErrorIndex === null || !report) return null
     const active = report.errors[activeErrorIndex]
-    if (active.page_no !== currentPage) return null
+    if (active.page_no !== currentPage - 1) return null
     return pageErrors.indexOf(active)
   }, [activeErrorIndex, report, currentPage, pageErrors])
 
@@ -129,22 +175,36 @@ export default function App() {
           <span className="viewer-eyebrow">NyayAI</span>
           <h1>{report.source_filename}</h1>
         </div>
-        <div className="viewer-page-nav">
-          <button
-            type="button"
-            disabled={currentPage <= 1}
-            onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
-          >
-            ← Prev
-          </button>
-          <span className="viewer-page-label">Page {currentPage}</span>
-          <button
-            type="button"
-            disabled={totalPages != null && currentPage >= totalPages}
-            onClick={() => setCurrentPage((p) => Math.min(totalPages ?? p + 1, p + 1))}
-          >
-            Next →
-          </button>
+        <div className="viewer-header-controls">
+          <div className="viewer-page-nav">
+            <button
+              type="button"
+              disabled={currentPage <= 1}
+              onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
+            >
+              ← Prev
+            </button>
+            <span className="viewer-page-label">Page {currentPage}</span>
+            <button
+              type="button"
+              disabled={totalPages != null && currentPage >= totalPages}
+              onClick={() => setCurrentPage((p) => Math.min(totalPages ?? p + 1, p + 1))}
+            >
+              Next →
+            </button>
+          </div>
+
+          <div className="viewer-zoom-nav">
+            <button type="button" onClick={zoomOut} disabled={zoom <= ZOOM_MIN} aria-label="Zoom out">
+              −
+            </button>
+            <button type="button" className="viewer-zoom-reset" onClick={resetZoom} title="Reset to fit width">
+              {Math.round(zoom * 100)}%
+            </button>
+            <button type="button" onClick={zoomIn} disabled={zoom >= ZOOM_MAX} aria-label="Zoom in">
+              +
+            </button>
+          </div>
         </div>
       </header>
 
@@ -155,9 +215,15 @@ export default function App() {
           onSelect={selectError}
         />
 
-        <div className="viewer-canvas-area">
+        <div className="viewer-canvas-area" ref={canvasAreaRef}>
           <div className="viewer-canvas-stack">
-            <PdfCanvas file={file} pageNumber={currentPage} onPageRendered={setPageInfo} />
+            <PdfCanvas
+              file={file}
+              pageNumber={currentPage}
+              containerWidth={containerWidth}
+              zoom={zoom}
+              onPageRendered={setPageInfo}
+            />
             <HighlightOverlay
               errors={pageErrors}
               displayScale={pageInfo?.displayScale}

--- a/frontend/src/ErrorList.jsx
+++ b/frontend/src/ErrorList.jsx
@@ -31,7 +31,7 @@ export default function ErrorList({ report, activeErrorIndex, onSelect }) {
               <span className="error-list-item-body">
                 <span className="error-list-item-text">{error.text}</span>
                 <span className="error-list-item-meta">
-                  p.{error.page_no} · {TYPE_LABELS[error.error_type] || error.error_type}
+                  p.{error.page_no + 1} · {TYPE_LABELS[error.error_type] || error.error_type}
                 </span>
                 {error.suggestion && <span className="error-list-item-suggestion">{error.suggestion}</span>}
               </span>

--- a/frontend/src/PdfCanvas.jsx
+++ b/frontend/src/PdfCanvas.jsx
@@ -4,11 +4,20 @@ import pdfWorkerUrl from 'pdfjs-dist/build/pdf.worker.mjs?url'
 
 pdfjsLib.GlobalWorkerOptions.workerSrc = pdfWorkerUrl
 
-// render at a fixed internal scale for crispness, independent of CSS display size
-const RENDER_SCALE = 1.5
+// raster resolution is capped as a multiple of the CSS display scale, not
+// the PDF's own point size - without this, zooming in with the buttons
+// below would render at 1x-ish internal resolution and just look blurry
+// once CSS stretched it up. capped at 4 so a large zoom on a big page
+// doesn't blow past a sane canvas memory budget.
+const MAX_RASTER_SCALE = 4
 
 /*
-  renders `pageNumber` of `file` onto a canvas.
+  renders `pageNumber` of `file` onto a canvas, sized to fill `containerWidth`
+  (times `zoom`) rather than a fixed 1-CSS-pixel-per-PDF-point size - a
+  Letter/A4 page at 1:1 renders as a small rectangle lost in a mostly-empty
+  viewer on any normal-sized monitor. containerWidth comes from App.jsx's
+  ResizeObserver on the canvas area; zoom is the user-controlled multiplier
+  on top of that fit-to-width baseline (1.0 = fit exactly).
 
   reports back { widthPts, heightPts, displayScale, numPages } via
   onPageRendered so HighlightOverlay/MarginRail can convert ErrorSpan
@@ -26,7 +35,7 @@ const RENDER_SCALE = 1.5
   was inside the same effect keyed on `[file, pageNumber]`) - splitting it
   out means turning pages only ever calls the cheap `doc.getPage(...)`.
 */
-export default function PdfCanvas({ file, pageNumber, onPageRendered }) {
+export default function PdfCanvas({ file, pageNumber, containerWidth, zoom, onPageRendered }) {
   const canvasRef = useRef(null)
   const [error, setError] = useState(null)
   const [doc, setDoc] = useState(null)
@@ -75,14 +84,25 @@ export default function PdfCanvas({ file, pageNumber, onPageRendered }) {
         if (cancelled) return
 
         const viewportAtScale1 = page.getViewport({ scale: 1 })
-        const viewport = page.getViewport({ scale: RENDER_SCALE })
+
+        // fitScale fills containerWidth exactly at zoom=1; falls back to
+        // 1:1 point-to-CSS-pixel sizing if containerWidth isn't known yet
+        // (first paint, before the ResizeObserver in App.jsx has measured
+        // anything) rather than flashing a 0-width canvas.
+        const fitScale = containerWidth
+          ? containerWidth / viewportAtScale1.width
+          : 1
+        const displayScale = fitScale * (zoom || 1)
+
+        const rasterScale = Math.min(displayScale, MAX_RASTER_SCALE)
+        const viewport = page.getViewport({ scale: rasterScale })
 
         const canvas = canvasRef.current
         const ctx = canvas.getContext('2d')
         canvas.width = viewport.width
         canvas.height = viewport.height
-        canvas.style.width = `${viewport.width / RENDER_SCALE}px`
-        canvas.style.height = `${viewport.height / RENDER_SCALE}px`
+        canvas.style.width = `${viewportAtScale1.width * displayScale}px`
+        canvas.style.height = `${viewportAtScale1.height * displayScale}px`
 
         renderTask = page.render({ canvasContext: ctx, viewport })
         await renderTask.promise
@@ -91,15 +111,10 @@ export default function PdfCanvas({ file, pageNumber, onPageRendered }) {
         onPageRendered?.({
           widthPts: viewportAtScale1.width,
           heightPts: viewportAtScale1.height,
-          // CSS-displayed width divided by point width = what HighlightOverlay
-          // and MarginRail multiply raw bbox coordinates by. this always
-          // equals exactly 1.0 today, because canvas.style.width above is
-          // set to viewportAtScale1.width (no zoom control exists yet) - it's
-          // written as a division rather than hardcoded so that when a zoom
-          // feature sets canvas.style.width to viewportAtScale1.width * zoom
-          // instead, this keeps computing the right value with no changes
-          // needed in HighlightOverlay or MarginRail.
-          displayScale: viewport.width / RENDER_SCALE / viewportAtScale1.width,
+          // CSS-displayed width divided by point width - what HighlightOverlay
+          // and MarginRail multiply raw bbox coordinates by to land on the
+          // right on-screen pixel regardless of fit-to-width sizing or zoom.
+          displayScale,
           numPages: doc.numPages,
         })
       } catch (err) {
@@ -112,7 +127,7 @@ export default function PdfCanvas({ file, pageNumber, onPageRendered }) {
       cancelled = true
       renderTask?.cancel()
     }
-  }, [doc, pageNumber, onPageRendered])
+  }, [doc, pageNumber, containerWidth, zoom, onPageRendered])
 
   if (error) {
     return <div className="pdf-canvas-error">Couldn't render this page: {error}</div>

--- a/frontend/src/mockData.js
+++ b/frontend/src/mockData.js
@@ -12,7 +12,7 @@ export function buildMockReport(sourceFilename) {
     {
       text: 'Section 302 IPC',
       error_type: 'citation',
-      page_no: 1,
+      page_no: 0,
       x0: 120, y0: 180, x1: 260, y1: 198,
       bbox: [120, 180, 260, 198],
       suggestion: 'verify Section 302 IPC exists and is active - consider Section 103 BNS',
@@ -23,7 +23,7 @@ export function buildMockReport(sourceFilename) {
     {
       text: 'recieved',
       error_type: 'spelling',
-      page_no: 1,
+      page_no: 0,
       x0: 90, y0: 260, x1: 160, y1: 278,
       bbox: [90, 260, 160, 278],
       suggestion: 'received',
@@ -36,7 +36,7 @@ export function buildMockReport(sourceFilename) {
     {
       text: 'has been went',
       error_type: 'grammar',
-      page_no: 1,
+      page_no: 0,
       x0: 200, y0: 340, x1: 320, y1: 358,
       bbox: [200, 340, 320, 358],
       suggestion: 'has gone',
@@ -47,7 +47,7 @@ export function buildMockReport(sourceFilename) {
     {
       text: 'Rakesh Kumar',
       error_type: 'entity',
-      page_no: 1,
+      page_no: 0,
       x0: 130, y0: 480, x1: 260, y1: 498,
       bbox: [130, 480, 260, 498],
       suggestion: 'should be "Ramesh Kumar"',
@@ -58,7 +58,7 @@ export function buildMockReport(sourceFilename) {
     {
       text: 'Patana',
       error_type: 'entity',
-      page_no: 2,
+      page_no: 1,
       x0: 150, y0: 220, x1: 220, y1: 238,
       bbox: [150, 220, 220, 238],
       suggestion: 'should be "Patna"',

--- a/renderer/annotate_pdf.py
+++ b/renderer/annotate_pdf.py
@@ -38,6 +38,13 @@ def annotate(pdf_path: Path, errors: list[ErrorSpan], output_path: Path) -> int:
     undercount if noise-filtering strips every span on a page), so callers
     that need total_pages (see services/analysis.py -> build_report) get
     it from here instead of opening the PDF a second time.
+
+    ErrorSpan.page_no is 0-indexed (ocr/native_extractor.py and
+    ocr/surya_extractor.py both build it via plain enumerate(pages) /
+    pymupdf's doc[i], neither passes start=1), so the loop below has to
+    be 0-indexed too - looping with enumerate(..., start=1) here used to
+    mean every page's highlight boxes got drawn one page later than
+    where the actual error is.
     """
     reader = PdfReader(str(pdf_path))
     writer = PdfWriter()
@@ -45,7 +52,7 @@ def annotate(pdf_path: Path, errors: list[ErrorSpan], output_path: Path) -> int:
     errors_by_page = _group_by_page(errors)
     total_pages = len(reader.pages)
 
-    for page_no, page in enumerate(reader.pages, start=1):
+    for page_no, page in enumerate(reader.pages):
         page_errors = errors_by_page.get(page_no, [])
         if page_errors:
             width = float(page.mediabox.width)


### PR DESCRIPTION
## What
Fixes #83 
- Fixed a page-numbering mismatch between the backend and two consumers of `ErrorSpan.page_no`:
  - `renderer/annotate_pdf.py` looped 1-indexed while `page_no` (from `ocr/native_extractor.py` / `ocr/surya_extractor.py`, both 0-indexed) isn't — every highlight box in the downloadable annotated PDF was drawn one page later than the real error.
  - `frontend/src/App.jsx` filtered `errors[].page_no === currentPage` where `currentPage` is 1-indexed (to match pdf.js) — errors showed correctly in the sidebar list but never highlighted on the canvas.
- `frontend/src/ErrorList.jsx` now displays `p.1` instead of `p.0` for the first page.
- PDF viewer now fits the page to the available width by default instead of a fixed 1-CSS-pixel-per-PDF-point size (which rendered as a small rectangle in a mostly-empty viewer on any normal monitor).
- Added zoom in/out/reset controls in the header (40%–300%, 15% steps). Raster resolution now tracks actual display scale (capped at 4x) instead of a fixed constant, so zooming in stays crisp.

## Why

Surfaced while testing the real upload flow end-to-end: a spelling error showed up in the sidebar as `p.0` and never highlighted on the page, and separately the PDF itself rendered tiny with a lot of dead space around it.

## How it was verified

- Built a real 2-page PDF and confirmed via `pypdf` that a `page_no=0` error now only gets drawn on physical page 1 (previously landed on page 2).
- `npm run build` clean, no warnings beyond the existing chunk-size notice.
- Manually walked through `App.jsx`'s `pageErrors`/`activeIndexOnPage` conversions and `PdfCanvas.jsx`'s `fitScale`/`rasterScale` math.

## Notes

- `mockData.js` updated to the real 0-indexed convention so local dev without a backend still matches production behavior.
- Caught and fixed a bug in my own first pass: the `ResizeObserver` effect was keyed on `[]`, but the canvas area `<div>` doesn't exist until `report` is set, so the observer would never have attached. Now keyed on `[report]`.