### PR TITLE
fixes 85, cuda OOM issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ export PYTHONPATH := $(CURDIR)
 
 .PHONY: \
 	test-ocr \
+	worker \
 	cleanup-outputs \
 	download-models \
 	ingest-corpus \
@@ -13,6 +14,9 @@ export PYTHONPATH := $(CURDIR)
 
 test-ocr:
 	uv run python tests/test_ocr.py $(FILE)
+
+worker:
+	uv run celery -A workers.celery_app worker --loglevel=info -Q pdf_processing --pool=solo
 
 cleanup-outputs:
 	uv run python scripts/cleanup_outputs.py $(ARGS)

--- a/README.md
+++ b/README.md
@@ -139,11 +139,24 @@ uv run uvicorn api.main:app --reload
 
 **a worker** (needed for anything to actually get processed):
 ```bash
-uv run celery -A workers.celery_app worker --loglevel=info -Q pdf_processing
+uv run celery -A workers.celery_app worker --loglevel=info -Q pdf_processing --pool=solo
 ```
 the `-Q pdf_processing` isn't optional - a worker only consumes queues it's
 explicitly told to listen on. leaving it off means uploads just sit there
 forever with no error at all (found this out the hard way).
+
+`--pool=solo` isn't optional either, for a different reason: without it,
+Celery defaults to the `prefork` pool and forks one child process per CPU
+core. Each of those child processes independently imports `model.predict`
+and `ocr.surya_extractor` and loads its *own* copy of InLegalBERT and
+Surya's detection/recognition models onto the GPU the first time it picks
+up a task - the module-level caches in those files only dedupe loads
+*within* a process, not across forked siblings. On a 6GB card, two or
+three prefork children processing documents at the same time is enough
+to blow the VRAM budget on its own, independent of any single document's
+size. `--pool=solo` runs everything in one process, one task at a time,
+which matches this project's single-GPU, single-machine deployment
+target anyway.
 
 **frontend:**
 ```bash

--- a/docs/api.md
+++ b/docs/api.md
@@ -292,13 +292,25 @@ backend (see `config/settings.py` / `workers/celery_app.py`). There is no
 uv run uvicorn api.main:app --reload
 ```
 
-**start a Celery worker — the `-Q pdf_processing` flag is mandatory:**
+**start a Celery worker — the `-Q pdf_processing` flag is mandatory, and so is `--pool=solo`:**
 ```bash
-uv run celery -A workers.celery_app worker --loglevel=info -Q pdf_processing
+uv run celery -A workers.celery_app worker --loglevel=info -Q pdf_processing --pool=solo
 ```
 A Celery worker only consumes queues it's explicitly told to listen on.
 Omitting `-Q pdf_processing` means uploaded PDFs get enqueued but never
 picked up — no error, no crash, the job just sits in `PENDING` forever.
+
+`--pool=solo` matters just as much on a GPU-backed single machine: the
+default `prefork` pool spawns one child process per CPU core, and each
+child loads its own copy of InLegalBERT + Surya onto the GPU the moment
+it handles its first task. The module-level model caches in
+`model/predict.py` and `ocr/surya_extractor.py` only prevent reloading
+*within* a process — they do nothing to stop several forked processes
+from each holding a full set of models in VRAM simultaneously. On a 6GB
+card that's enough on its own to cause `CUDA out of memory`, regardless
+of how large any individual document is. `--pool=solo` keeps everything
+in one process handling one task at a time, which is the correct shape
+for this deployment target.
 
 All three (Qdrant, API, worker) need to be running for the full pipeline
 to work end to end.

--- a/ocr/pipeline.py
+++ b/ocr/pipeline.py
@@ -47,8 +47,11 @@ def extract(
     if scanned_pages:
         # Lazy import so Surya models only load when actually needed
         from ocr.surya_extractor import SuryaExtractor
-        surya = SuryaExtractor()
-        spans.extend(surya.extract(pdf_path, scanned_pages))
+        # `with` guarantees clear_cache() runs even if extract() raises -
+        # SuryaExtractor defines __enter__/__exit__ for exactly this, it
+        # just wasn't being used here before.
+        with SuryaExtractor() as surya:
+            spans.extend(surya.extract(pdf_path, scanned_pages))
     
     # Filter noise
     if filter_noise:

--- a/ocr/surya_extractor.py
+++ b/ocr/surya_extractor.py
@@ -13,8 +13,10 @@ Improvements:
 - Batch processing with memory optimization
 """
 
+import logging
 import pypdfium2 as pdfium
 import re
+import torch
 from PIL import Image
 from pathlib import Path
 from typing import Optional, List, Dict, Any, Tuple
@@ -23,6 +25,41 @@ from surya.detection import DetectionPredictor
 from surya.recognition import RecognitionPredictor
 
 from ocr.tokens import LineSpan
+
+logger = logging.getLogger(__name__)
+
+
+# module-level cache so surya's detection + recognition weights only get
+# loaded onto the GPU once per process, not once per document.
+#
+# before this fix: ocr/pipeline.py did `surya = SuryaExtractor()` fresh for
+# every document that had at least one scanned page, and __init__ used to
+# build brand new DetectionPredictor()/RecognitionPredictor() instances
+# every single call. those constructors push real model weights onto CUDA.
+# the old instance only gets freed once python's GC actually collects it -
+# refcounting usually handles that fast, but a Celery worker can pick up
+# the next scanned document before the previous predictor object is fully
+# torn down, and torch's caching allocator doesn't always hand freed VRAM
+# back cleanly under that kind of back-to-back churn. over a worker's
+# lifetime (many documents, some with scanned pages) this is exactly the
+# kind of thing that manifests as "works for the first few PDFs, OOMs
+# later" rather than an immediate crash.
+#
+# model/predict.py already solved this exact problem for InLegalBERT with
+# a module-level cache - this mirrors that pattern for surya.
+_CACHED_DETECTION_PREDICTOR: Optional[DetectionPredictor] = None
+_CACHED_RECOGNITION_PREDICTOR: Optional[RecognitionPredictor] = None
+
+
+def _get_shared_predictors() -> Tuple[DetectionPredictor, RecognitionPredictor]:
+    global _CACHED_DETECTION_PREDICTOR, _CACHED_RECOGNITION_PREDICTOR
+
+    if _CACHED_DETECTION_PREDICTOR is None:
+        logger.info("loading surya detection + recognition models (first use this process)")
+        _CACHED_DETECTION_PREDICTOR = DetectionPredictor()
+        _CACHED_RECOGNITION_PREDICTOR = RecognitionPredictor()
+
+    return _CACHED_DETECTION_PREDICTOR, _CACHED_RECOGNITION_PREDICTOR
 
 
 class SuryaExtractor:
@@ -63,12 +100,22 @@ class SuryaExtractor:
         self.min_confidence = min_confidence
         self.detect_layout = detect_layout
         
-        # Load models once, reuse across all pages
-        # Don't reinstantiate per page
-        self.detection_predictor = DetectionPredictor()
-        self.recognition_predictor = RecognitionPredictor()
+        # Reuse the process-wide detection/recognition models instead of
+        # loading fresh weights onto the GPU every time a SuryaExtractor is
+        # constructed (one per document, see ocr/pipeline.py) - see
+        # _get_shared_predictors() above for why this matters for VRAM.
+        self.detection_predictor, self.recognition_predictor = _get_shared_predictors()
         
-        # Cache for rendered pages to avoid re-rendering
+        # Cache for rendered pages of *this* extraction only, to avoid
+        # re-rendering a page if it's requested twice within the same
+        # extract() call. Deliberately instance-scoped (not module-level
+        # like the predictors above) and keyed only by page_no - a
+        # module-level cache would return page 3 of a previous, unrelated
+        # document when the current document also has a page 3. A fresh
+        # SuryaExtractor per document keeps that from happening, and
+        # clear_cache() (called automatically at the end of extract())
+        # drops the PIL images as soon as this document is done with them
+        # instead of waiting on __del__/GC.
         self._image_cache: Dict[int, Image.Image] = {}
     
     def _render_pages(
@@ -306,6 +353,18 @@ class SuryaExtractor:
                     
                     if span.is_valid():
                         all_spans.append(span)
+        
+        # This document is done - drop the rendered PIL images now rather
+        # than waiting for this SuryaExtractor instance to be garbage
+        # collected (ocr/pipeline.py doesn't use the `with` form, so
+        # __exit__/clear_cache() would otherwise never run). Also ask torch
+        # to hand back any now-unused cached CUDA blocks - image batch
+        # sizes vary per document, so freeing here reduces fragmentation
+        # on the 6GB card instead of letting the allocator hold onto the
+        # largest batch it ever saw.
+        self.clear_cache()
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
         
         return all_spans
     


### PR DESCRIPTION
# Summary

Fixes #85

CUDA OOM had three compounding causes, not one. Fixed all three: (1) the
Celery worker was missing `--pool=solo`, so the default `prefork` pool let
multiple forked processes each load a full copy of InLegalBERT + Surya
onto the same GPU; (2) `SuryaExtractor` reloaded fresh detection/recognition
weights onto the GPU for every single document instead of caching them
like `model/predict.py` already does for InLegalBERT; (3) the extractor's
own `clear_cache()`/context-manager cleanup existed but was never actually
invoked by the caller.

---

# Changes

- `ocr/surya_extractor.py`: added a module-level singleton cache for
  `DetectionPredictor`/`RecognitionPredictor` (same pattern as
  `model/predict.py`'s `_load_model_and_tokenizer()`), so weights load onto
  the GPU once per process instead of once per document. `extract()` now
  calls `clear_cache()` and `torch.cuda.empty_cache()` at the end of every
  document to release the per-document image cache and hand back unused
  CUDA blocks.
- `ocr/pipeline.py`: uses `with SuryaExtractor() as surya:` so cleanup
  actually runs (the class already defined `__enter__`/`__exit__`, it just
  wasn't being used).
- `README.md`, `docs/api.md`: worker startup command now includes
  `--pool=solo`, with an explanation of why — without it, Celery's default
  `prefork` pool forks one child per CPU core, and each child independently
  loads its own copy of every model onto the GPU, which alone is enough to
  OOM a 6GB card regardless of document size.
- `Makefile`: added a `worker` target with the correct flags baked in.

---

# Testing

---

# Documentation

- [x] Documentation updated (`README.md`, `docs/api.md` worker command +
      rationale)

---

# Checklist

- [x] No unnecessary files committed
- [x] Code follows project conventions
- [ ] Ready for review